### PR TITLE
Add design updates

### DIFF
--- a/assets/styles/main.scss
+++ b/assets/styles/main.scss
@@ -31,11 +31,6 @@ footer {
   width: 100%;
 }
 
-.footer-fixed {
-  bottom: 0;
-  position: absolute;
-}
-
 .footer-inner {
   @include margin(null $site-margins);
   align-items: center;
@@ -59,12 +54,24 @@ footer {
 // Home page ------------ //
 
 .page-vote {
-  background-color: #286397; // fallback color
-  @include linear-gradient(#225BA0, #1C4B84);
-
   h1,
   label {
     color: $color-white;
+  }
+
+  // hack to remove margin and replace with padding for background color issues
+  .usa-display {
+    margin: 0;
+    padding-top: $site-margins;
+
+    @include media($medium-screen) {
+      padding-top: 1.5em;
+    }
+  }
+
+  .page-vote-main {
+    background-color: #286397; // fallback color
+    @include linear-gradient(#225BA0, #1C4B84);
   }
 }
 

--- a/assets/styles/main.scss
+++ b/assets/styles/main.scss
@@ -73,6 +73,24 @@ footer {
     background-color: #286397; // fallback color
     @include linear-gradient(#225BA0, #1C4B84);
   }
+
+  .page-inner {
+    min-height: 60rem;
+  }
+
+  footer {
+    position: relative;
+  }
+}
+
+.img-ballot_box {
+  bottom: -3.5rem;
+  text-align: center;
+  position: absolute;
+  right: 0;
+  left: 0;
+  margin: 0 auto;
+  width: 175px;
 }
 
 .form-register {
@@ -85,18 +103,6 @@ footer {
   button {
     width: 100%;
   }
-}
-
-.img-ballot_box-2 {
-  width: 175px;
-  margin-top: 6rem;
-}
-
-.img-ballot_box {
-  bottom: 0;
-  width: 175px;
-  position: absolute;
-  right: 40%;
 }
 
 .ballot-container {

--- a/assets/styles/main.scss
+++ b/assets/styles/main.scss
@@ -59,7 +59,8 @@ footer {
 // Home page ------------ //
 
 .page-vote {
-  background-color: #286397;
+  background-color: #286397; // fallback color
+  @include linear-gradient(#225BA0, #1C4B84);
 
   h1,
   label {

--- a/assets/styles/main.scss
+++ b/assets/styles/main.scss
@@ -33,16 +33,28 @@ footer {
 
 .footer-inner {
   @include margin(null $site-margins);
-  align-items: center;
-  background-color: $color-white;
-  display: flex;
-  float: right;
-  text-align: right;
+
+  @include media($medium-screen) {
+    align-items: center;
+    background-color: $color-white;
+    display: flex;
+    float: right;
+    text-align: right;
+  }
 
   a {
     color: $color-base;
     font-size: $h6-font-size;
     text-transform: uppercase;
+
+    &:nth-child(2) {
+      float: right;
+      margin-top: 1rem;
+
+      @include media($medium-screen) {
+        margin-top: 0;
+      }
+    }
   }
 
   img {

--- a/assets/styles/main.scss
+++ b/assets/styles/main.scss
@@ -100,7 +100,7 @@ footer {
     max-width: 300px;
   }
 
-  button {
+  [type="submit"] {
     width: 100%;
   }
 }

--- a/assets/styles/main.scss
+++ b/assets/styles/main.scss
@@ -75,10 +75,15 @@ footer {
   }
 
   .page-inner {
-    min-height: 60rem;
+    min-height: 50rem;
+
+    @include media($medium-screen) {
+      min-height: 60rem;
+    }
   }
 
   footer {
+    height: 2rem;
     position: relative;
   }
 }

--- a/assets/styles/main.scss
+++ b/assets/styles/main.scss
@@ -90,11 +90,11 @@ footer {
 
 .img-ballot_box {
   bottom: -3.5rem;
-  text-align: center;
-  position: absolute;
-  right: 0;
   left: 0;
   margin: 0 auto;
+  position: absolute;
+  right: 0;
+  text-align: center;
   width: 175px;
 }
 

--- a/assets/styles/main.scss
+++ b/assets/styles/main.scss
@@ -95,13 +95,13 @@ footer {
   }
 
   footer {
-    height: 2rem;
+    height: 6rem;
     position: relative;
   }
 }
 
 .img-ballot_box {
-  bottom: -3.5rem;
+  bottom: 5px;
   left: 0;
   margin: 0 auto;
   position: absolute;

--- a/assets/styles/main.scss
+++ b/assets/styles/main.scss
@@ -17,9 +17,11 @@ h1 {
 .usa-display {
   font-size: $h1-font-size;
   margin-bottom: .5em;
+  margin-top: $site-margins;
 
   @include media($medium-screen) {
     font-size: $title-font-size;
+    margin-top: 1.5em;
   }
 }
 

--- a/assets/styles/main.scss
+++ b/assets/styles/main.scss
@@ -98,7 +98,7 @@ footer {
 // Inner pages ---------- //
 
 .main-content {
-  padding-bottom: 4rem;
+  padding-bottom: 3rem;
 
   @include media($medium-screen) {
     min-height: 50rem;

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -33,7 +33,7 @@
           <a href="https://usa.gov/">
             <img src="{{ .Site.BaseURL }}assets/img/usagov-logo.png">
           </a>
-          <a href="#">Privacy policy</a>
+          <a class="footer-link-privacy" href="#">Privacy policy</a>
         </div>
       </footer>
       <!-- Footer END -->

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -18,7 +18,7 @@
               <option value="{{ .Slug}}">{{ title .Title }}</option>
             {{ end }}
           </select>
-          <button class="usa-button-secondary" id="js-user-submit" type="submit">Find out how to register</button>
+          <button class="usa-button-secondary usa-button-big" id="js-user-submit" type="submit">Find out how to register</button>
         </form>
       </div>
       <!-- Register END -->

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,7 +1,7 @@
 {{ partial "head.html" . }}
   <body class="page-vote">
 
-    <div id="main" role="main">
+    <div class="page-vote-main" id="main" role="main">
 
       <a class="skipnav" href="#main-content">Skip main navigation</a>
 
@@ -28,7 +28,7 @@
       </div>
 
       <!-- Footer BEGIN -->
-      <footer class="footer-fixed">
+      <footer>
       <!--
         <div class="ballot-container">
           <img class="img-ballot_box" src="{{ .Site.BaseURL }}assets/img/ballot_box-blue.svg" alt="Web design standards">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -18,7 +18,7 @@
               <option value="{{ .Slug}}">{{ title .Title }}</option>
             {{ end }}
           </select>
-          <button id="js-user-submit" type="submit" class="usa-button-secondary">Find out how to register</button>
+          <button class="usa-button-secondary" id="js-user-submit" type="submit">Find out how to register</button>
         </form>
       </div>
       <!-- Register END -->

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -23,17 +23,11 @@
       </div>
       <!-- Register END -->
 
-      <div class="ballot-container">
-        <img class="img-ballot_box-2" src="{{ .Site.BaseURL }}assets/img/ballot_box-blue.svg" alt="Web design standards">
-      </div>
-
       <!-- Footer BEGIN -->
       <footer>
-      <!--
         <div class="ballot-container">
           <img class="img-ballot_box" src="{{ .Site.BaseURL }}assets/img/ballot_box-blue.svg" alt="Web design standards">
         </div>
-       -->
 
         <div class="footer-inner">
           <a href="https://usa.gov/">

--- a/layouts/states/register-by-mail.html
+++ b/layouts/states/register-by-mail.html
@@ -1,4 +1,4 @@
-<div class="usa-grid page-inner">
+<div class="usa-grid page-inner main-content">
   <header>
     <h1 class="usa-display">Register to vote</h1>
   </header>


### PR DESCRIPTION
This adds the following design updates:

**Homepage**:
- [x] Change the footer to be not fixed and make the vote icon cut into footer 
- [x] Get a gradient colors background from @carodew and implement (the blue background top is #225BA0 and bottom is #1C4B84)

**Internal page**:
- [x] At mobile, reset margin top for h1 style and use 30px
- [x] Add padding to bottom of main content area

This is what it looks like:

<img width="1039" alt="screen shot 2016-05-13 at 4 06 45 pm" src="https://cloud.githubusercontent.com/assets/5249443/15264160/52d56e52-1925-11e6-9cde-655189abe370.png">

<img width="398" alt="screen shot 2016-05-13 at 4 36 36 pm" src="https://cloud.githubusercontent.com/assets/5249443/15264530/eedd98f8-1928-11e6-87d8-c83d4c2bee70.png">

![o0jezp5rnqecbagqiecaqhkbisgiejugueyjtr9icbhjm0f5bagqiecaaaecoqwghogvntij0trntg0bqktonle1aqiecbagqibacohfhohtlieiefmonwabagqiecbaikeaejfz31vngaabagqiecbaylsaedgazkicbagqiecaaaecoqweijz7rmocbagqiecaaaecowweinf0fhigqiaaaqiecbdikfcxepejt4suvxjmc9uaaaaasu](https://cloud.githubusercontent.com/assets/5249443/15264170/76cf3cfc-1925-11e6-80c9-bef7332d7b60.png)

cc: @ericadeahl @carodew @rogeruiz 

Partly addresses: https://github.com/18F/vote-gov/issues/10.