### PR TITLE
Add Browserify support

### DIFF
--- a/assets/scripts/start.js
+++ b/assets/scripts/start.js
@@ -1,0 +1,4 @@
+var $ = require('jquery');
+
+console.log('Federal Front Door: Vote.gov Scripts')
+console.log('jQuery version %s', $.fn.jquery);

--- a/config/gulp/build.js
+++ b/config/gulp/build.js
@@ -15,7 +15,7 @@ gulp.task('clean-all', function () {
 gulp.task('build', [ 'clean-all' ], function (done) {
   exports.printPackageInfo();
   gutil.log(gutil.colors.cyan('build'), 'Building asset-pipeline');
-  runSequence([ 'styles:homepage', /*'scripts',*/ 'images', 'fonts' ], done);
+  runSequence([ 'styles:homepage', 'scripts', 'images', 'fonts' ], done);
 });
 
 
@@ -48,7 +48,7 @@ gulp.task('build:website', [ 'build' ], function (done) {
 gulp.task('watch', function () {
   gutil.log(gutil.colors.cyan('watch'), 'Watching assets for changes');
   gulp.watch('./assets/styles/**/*.scss', [ 'styles:homepage' ]);
-  //gulp.watch('./assets/scripts/**/*.js', [ 'scripts' ]);
+  gulp.watch('./assets/scripts/**/*.js', [ 'scripts' ]);
   gulp.watch('./assets/images/**/*', [ 'images' ]);
 });
 

--- a/config/gulp/flags.js
+++ b/config/gulp/flags.js
@@ -1,17 +1,19 @@
-global.cFlags = {
+var gulp = require('gulp');
+var gutil = require('gulp-util');
+
+var cFlags = global.cFlags = {
   production: false,
   test: true,
 };
 
-//gulp.task('no-test', function (done) {
-  //gutil.log(gutil.colors.cyan('no-test'), 'Disabling tests');
-  //cFlags.test = false;
-  //done();
-//});
+gulp.task('no-test', function (done) {
+  gutil.log(gutil.colors.cyan('no-test'), 'Disabling tests');
+  cFlags.test = false;
+  done();
+});
 
-//gulp.task('production', function (done) {
-  //gutil.log(gutil.colors.cyan('production'), 'Enabling production tasks');
-  //cFlags.production = true;
-  //done();
-//});
-
+gulp.task('production', function (done) {
+  gutil.log(gutil.colors.cyan('production'), 'Enabling production tasks');
+  cFlags.production = true;
+  done();
+});

--- a/config/gulp/scripts.js
+++ b/config/gulp/scripts.js
@@ -3,43 +3,46 @@ var gutil = require('gulp-util');
 var eslint = require('gulp-eslint');
 var browserify = require('browserify');
 var uglify = require('gulp-uglify');
+var source = require('vinyl-source-stream');
+var buffer = require('vinyl-buffer');
+var rename = require('gulp-rename');
+var cFlags = global.cFlags;
 
-//gulp.task('eslint', function (done) {
+gulp.task('eslint', function (done) {
 
-  //if (!cFlags.test) {
-    //gutil.log(gutil.colors.cyan('eslint'), 'Disabling linting');
-    //return done();
-  //}
+  if (!cFlags.test) {
+    gutil.log(gutil.colors.cyan('eslint'), 'Disabling linting');
+    return done();
+  }
 
-  //return gulp.src('./assets/scripts/**/*.js')
-    //.pipe(eslint({
-      //configFile: './.eslintrc',
-    //}))
-    //.pipe(eslint.format());
+  return gulp.src('./assets/scripts/**/*.js')
+    .pipe(eslint({
+      configFile: './.eslintrc',
+    }))
+    .pipe(eslint.format());
 
-//});
+});
 
-//gulp.task('scripts', [ 'eslint' ], function () {
+gulp.task('scripts', [ 'eslint' ], function () {
 
-  //gutil.log(gutil.colors.cyan('scripts'), 'Browserifying JavaScript assets');
+  gutil.log(gutil.colors.cyan('scripts'), 'Browserifying JavaScript assets');
 
-  //var bundle = browserify({
-    //entries: './assets/scripts/start.js',
-    //debug: true,
-  //}).bundle();
+  var bundle = browserify({
+    entries: './assets/scripts/start.js',
+    debug: true,
+  }).bundle();
 
-  //bundle = bundle.pipe(source('start.js'))
-    //.pipe(buffer());
+  bundle = bundle.pipe(source('start.js'))
+    .pipe(buffer());
 
-  //if (cFlags.production) {
-    //gutil.log(gutil.colors.cyan('scripts'), 'Compressing scripts');
-    //bundle = bundle.pipe(uglify());
-  //}
+  if (cFlags.production) {
+    gutil.log(gutil.colors.cyan('scripts'), 'Compressing scripts');
+    bundle = bundle.pipe(uglify());
+  }
 
-  //bundle = bundle.pipe(rename('main.js'))
-    //.pipe(gulp.dest('./static/assets/scripts'));
+  bundle = bundle.pipe(rename('main.js'))
+    .pipe(gulp.dest('./static/assets/scripts'));
 
-  //return bundle;
+  return bundle;
 
-//});
-
+});

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,11 +3,11 @@
 // be used by Hugo.
 
 // Bring in individual gulp configs
+require('./config/gulp/flags');
 require('./config/gulp/styles');
 require('./config/gulp/scripts');
 require('./config/gulp/images');
 require('./config/gulp/fonts');
-require('./config/gulp/flags');
 var build = require('./config/gulp/build');
 
 var gulp = require('gulp');

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -41,10 +41,7 @@
     </div>
 
     {{ partial "analytics.html" . }}
-
-    {{/*
     {{ partial "scripts.html" . }}
-    */}}
 
     <script>
       // TODO: This exists only for basic testing. It will be removed once

--- a/layouts/states/single.html
+++ b/layouts/states/single.html
@@ -14,5 +14,6 @@
       {{ partial "footer.html" . }}
     </div>
     {{ partial "analytics.html" . }}
+    {{ partial "scripts.html" . }}
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
   "devDependencies": {
     "browserify": "^13.0.0",
     "del": "^2.2.0",
+    "eslint": "^2.10.2",
+    "eslint-config-airbnb-base": "^3.0.1",
+    "eslint-plugin-import": "^1.8.0",
     "gulp": "^3.9.1",
     "gulp-eslint": "^2.0.0",
     "gulp-filter": "^3.0.1",


### PR DESCRIPTION
This patch adds the Browserify support from the `ffd-*` projects to the
repo. The entry point for the JavaScript is in `assets/scripts/start.js`
Modules can be referenced from any directory within `assets/scripts/`.