### PR TITLE
Add base files from `ffd-toolkit`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# For more info, see http://EditorConfig.org.
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 2
+
+[{*.md}]
+indent_style = space
+indent_size = 4

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,10 @@
+{
+    "rules": {},
+    "env": {
+        "node": true,
+        "browser": true
+    },
+    "extends": [
+      "airbnb-base/legacy"
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "url": "https://github.com/18F/vote-gov/issues"
   },
   "homepage": "https://github.com/18F/vote-gov#readme",
+  "license": "CC0-1.0",
   "devDependencies": {
     "browserify": "^13.0.0",
     "del": "^2.2.0",


### PR DESCRIPTION
This patch series adds the base `dot-files` to the repository regarding ESLint and EditorConfig from the `ffd-toolkit`.