### PR TITLE
Remove trailing slash in logo link

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -4,7 +4,7 @@
   <nav class="usa-grid">
     <div class="site-logo" id="logo">
       <h1>
-        <a href="{{ .Site.BaseURL }}/" accesskey="1" title="Home" aria-label="Home">vote.gov</a>
+        <a href="{{ .Site.BaseURL }}" accesskey="1" title="Home" aria-label="Home">vote.gov</a>
       </h1>
     </div>
   </nav>


### PR DESCRIPTION
There's an extra slash on the staging site when you click the logo link. This removes the slash from it.

Extra slash:
<img width="325" alt="screen shot 2016-05-20 at 12 57 46 pm" src="https://cloud.githubusercontent.com/assets/5249443/15440500/9d270c12-1e8a-11e6-9063-4e98baef7ef1.png">
