### PR TITLE
Add installation script for Hugo

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -23,7 +23,7 @@ test:
   pre:
     - gulp -v
     - scss-lint -v
-    - hugo -v
+    - hugo version
 
 deployment:
   production:

--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,9 @@
 machine:
+  environment:
+    CIRCLE_BUILD_DIR: $HOME/$CIRCLE_PROJECT_REPONAME
+    PATH: $PATH:$CIRCLE_BUILD_DIR/bin
+  post:
+    - mkdir -p $CIRCLE_BUILD_DIR/bin
   node:
     version: 5.1.0
 
@@ -9,8 +14,16 @@ dependencies:
     - sudo dpkg -i debs/temp.deb
     - cf -v
     - rm -rf ./node_modules
+    - bash ./config/ci/install-hugo.sh
   cache_directories:
     - debs
+    - bin
+
+test:
+  pre:
+    - gulp -v
+    - scss-lint -v
+    - hugo -v
 
 deployment:
   production:

--- a/config/ci/install-hugo.sh
+++ b/config/ci/install-hugo.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+set -x
+
+HUGO_VERSION="0.15"
+
+# Install Hugo
+if [ ! -e $CIRCLE_BUILD_DIR/bin/hugo ] || ! [[ `hugo version` =~ v${HUGO_VERSION} ]]; then
+  wget https://github.com/spf13/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_linux_amd64.tar.gz
+  tar xvfz hugo_${HUGO_VERSION}_linux_amd64.tar.gz
+  cp hugo_${HUGO_VERSION}_linux_amd64/hugo_${HUGO_VERSION}_linux_amd64 $CIRCLE_BUILD_DIR/bin/hugo
+fi


### PR DESCRIPTION
This patch series adds a `install-hugo` shell script which will pull a versioned version of `hugo` from the Github releases of the `spf13/hugo` repository.

The work for this script was done by @nathany, [repo reference](https://github.com/nathany/hugo-deploy), and [discussed here in the Hugo Discourse](https://discuss.gohugo.io/t/my-deployment-process/807).

I tested this script locally to ensure that the script worked by downloading the correctly versioned file to my local directory. ~~I will test this on CircleCI using the `Build with SSH` feature and post the results.~~ The output of `hugo version` should confirm that `hugo` has been installed in the `$PATH`.