### PR TITLE
Update "learn more" link on "No registration needed" page

### DIFF
--- a/content/register/north-dakota.md
+++ b/content/register/north-dakota.md
@@ -1,6 +1,6 @@
 +++
 date = "2016-05-10T09:55:36-04:00"
-external_link = ""
+external_link = "https://vip.sos.nd.gov/PortalList.aspx"
 registration_type = "not-needed"
 state_abbreviation = "ND"
 title = "North Dakota"

--- a/layouts/register/types/not-needed.html
+++ b/layouts/register/types/not-needed.html
@@ -5,7 +5,7 @@
   </header>
   <p class="usa-font-lead">{{ .Title }} only requires that you bring a valid state ID to your polling place.</p>
   <p>
-    <a href="#">Learn more about voting</a>
+    <a href="{{ .Params.external_link }}?ref={{ .Site.Params.Referrer_Short_Code }}">Learn more about voting</a>
   </p>
 </div>
 <!-- Register END -->

--- a/layouts/register/types/not-needed.html
+++ b/layouts/register/types/not-needed.html
@@ -5,7 +5,7 @@
   </header>
   <p class="usa-font-lead">{{ .Title }} only requires that you bring a valid state ID to your polling place.</p>
   <p>
-    <a href="{{ .Params.external_link }}?ref={{ .Site.Params.Referrer_Short_Code }}">Learn more about voting</a>
+    <a href="{{ .Params.external_link }}?ref={{ .Site.Params.Referrer_Short_Code }}">Learn more about voting in {{ .Title }}</a>
   </p>
 </div>
 <!-- Register END -->


### PR DESCRIPTION
This PR:
- Adds link to external sites for "learn more"
- Updates text to say: "Learn more about voting in [your state]"

This is what it looks like:

<img width="657" alt="screen shot 2016-05-27 at 12 34 17 pm" src="https://cloud.githubusercontent.com/assets/5249443/15619213/cbb6ca18-2407-11e6-8cfe-900de4b9e542.png">

Resolves: #65.