### PR TITLE
Fix deployments

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -30,13 +30,13 @@ deployment:
     branch: [master]
     commands:
       - echo "CURRENTLY ONLY BUILDING SINGLE LANGUAGE SITE"
-      - SITE_BASEURL="$CF_GSA_VOTE_PRODUCTION_URL" gulp build:website
+      - npm run build:production
       - cf login -a https://api.cloud.gov -u $CF_GSA_VOTE_USER -p $CF_GSA_VOTE_PASS -o gsa-ffd -s vote-production
       - cf push
   staging:
     branch: [staging]
     commands:
       - echo "CURRENTLY ONLY BUILDING SINGLE LANGUAGE SITE"
-      - SITE_BASEURL="$CF_GSA_VOTE_STAGING_URL" gulp build:website
+      - npm run build:staging
       - cf login -a https://api.cloud.gov -u $CF_GSA_VOTE_USER -p $CF_GSA_VOTE_PASS -o gsa-ffd -s vote-staging
       - cf push -f manifest-staging.yml

--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,3 @@
-languageCode = "en-us"
 title = "Voter Registration"
 
 # Taxnomies used to categorize states and territories by registration type
@@ -9,3 +8,4 @@ registration_type = "registration_types"
 [params]
 Owner = "USA.gov"
 Referrer_Short_Code = "voteusa"
+lang = "en-US"

--- a/config_en.toml
+++ b/config_en.toml
@@ -1,6 +1,0 @@
-baseurl = "https://vote.usa.gov/"
-languageCode = "en-us"
-title = "Voter Registration"
-
-[params]
-lang = "en-US"

--- a/config_es.toml
+++ b/config_es.toml
@@ -1,4 +1,3 @@
-languageCode = "es"
 title = "Voter Registration but in spanish"
 
 [params]

--- a/package.json
+++ b/package.json
@@ -3,29 +3,31 @@
   "version": "1.0.0",
   "main": "gulpfile.js",
   "config": {
-    "hugo": {
-      "en": "config.toml",
-      "es": "config_es.toml"
-    },
-    "urls": {
-      "en": {
-        "staging": "https://vote-gov-staging.apps.cloud.gov/",
-        "production": "https://vote-gov.apps.cloud.gov/"
+    "votegov": {
+      "hugo": {
+        "en": "config.toml",
+        "es": "config_es.toml"
       },
-      "es": {
-        "staging": "https://vote-gov-staging.apps.cloud.gov/es/",
-        "production": "https://vote-gov.apps.cloud.gov/es/"
+      "urls": {
+        "en": {
+          "staging": "https://vote-gov-staging.apps.cloud.gov/",
+          "production": "https://vote-gov.apps.cloud.gov/"
+        },
+        "es": {
+          "staging": "https://vote-gov-staging.apps.cloud.gov/es/",
+          "production": "https://vote-gov.apps.cloud.gov/es/"
+        }
       }
     }
   },
   "scripts": {
     "postinstall": "gem install scss_lint",
-    "build:staging": "SITE_CONFIGPATH=$npm_package_config_hugo_en SITE_BASEURL=\"${npm_package_config_urls_en_staging}\" gulp build:website",
-    "build:production": "SITE_CONFIGPATH=$npm_package_config_hugo_en SITE_BASEURL=\"${npm_package_config_urls_en_production}\" gulp build:website",
-    "build:staging:spanish": "SITE_CONFIGPATH=$npm_package_config_hugo_es SITE_BASEURL=\"${npm_package_config_urls_es_staging}\" gulp build:website",
-    "build:production:spanish": "SITE_CONFIGPATH=$npm_package_config_hugo_es SITE_BASEURL=\"${npm_package_config_urls_es_production}\" gulp build:website",
-    "start": "SITE_CONFIGPATH=$npm_package_config_hugo_en SITE_BASEURL=\"http://localhost/\" gulp website",
-    "start:spanish": "SITE_CONFIGPATH=$npm_package_config_hugo_es SITE_BASEURL=\"http://localhost/es/\" gulp website",
+    "build:staging": "SITE_CONFIGPATH=$npm_package_config_votegov_hugo_en SITE_BASEURL=\"${npm_package_config_votegov_urls_en_staging}\" gulp build:website",
+    "build:production": "SITE_CONFIGPATH=$npm_package_config_votegov_hugo_en SITE_BASEURL=\"${npm_package_config_votegov_urls_en_production}\" gulp build:website",
+    "build:staging:spanish": "SITE_CONFIGPATH=$npm_package_config_votegov_hugo_es SITE_BASEURL=\"${npm_package_config_votegov_urls_es_staging}\" gulp build:website",
+    "build:production:spanish": "SITE_CONFIGPATH=$npm_package_config_votegov_hugo_es SITE_BASEURL=\"${npm_package_config_votegov_urls_es_production}\" gulp build:website",
+    "start": "SITE_CONFIGPATH=$npm_package_config_votegov_hugo_en SITE_BASEURL=\"http://localhost/\" gulp website",
+    "start:spanish": "SITE_CONFIGPATH=$npm_package_config_votegov_hugo_es SITE_BASEURL=\"http://localhost/es/\" gulp website",
     "test": "gulp test"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -2,15 +2,30 @@
   "name": "vote.gov",
   "version": "1.0.0",
   "main": "gulpfile.js",
+  "config": {
+    "hugo": {
+      "en": "config.toml",
+      "es": "config_es.toml"
+    },
+    "urls": {
+      "en": {
+        "staging": "https://vote-gov-staging.apps.cloud.gov/",
+        "production": "https://vote-gov.apps.cloud.gov/"
+      },
+      "es": {
+        "staging": "https://vote-gov-staging.apps.cloud.gov/es/",
+        "production": "https://vote-gov.apps.cloud.gov/es/"
+      }
+    }
+  },
   "scripts": {
     "postinstall": "gem install scss_lint",
-    "build": "gulp build:website",
-    "build-staging": "SITE_BASEURL=\"https://vote-gov-staging.apps.cloud.gov\" gulp build:website",
-    "build-production": "SITE_BASEURL=\"https://vote-gov.apps.cloud.gov\" gulp build:website",
-    "build-staging-spanish": "SITE_CONFIGPATH=config_es.toml SITE_BASEURL=\"https://vote-gov-staging.apps.cloud.gov/es/\" gulp build:website",
-    "build-production-spanish": "SITE_CONFIGPATH=config_es.toml SITE_BASEURL=\"https://vote-gov.apps.cloud.gov/es/\" gulp build:website",
-    "start": "SITE_BASEURL=\"http://localhost/\" gulp website",
-    "start-spanish": "SITE_CONFIGPATH=config_es.toml SITE_BASEURL=\"http://localhost/es/\" gulp website",
+    "build:staging": "SITE_CONFIGPATH=$npm_package_config_hugo_en SITE_BASEURL=\"${npm_package_config_urls_en_staging}\" gulp build:website",
+    "build:production": "SITE_CONFIGPATH=$npm_package_config_hugo_en SITE_BASEURL=\"${npm_package_config_urls_en_production}\" gulp build:website",
+    "build:staging:spanish": "SITE_CONFIGPATH=$npm_package_config_hugo_es SITE_BASEURL=\"${npm_package_config_urls_es_staging}\" gulp build:website",
+    "build:production:spanish": "SITE_CONFIGPATH=$npm_package_config_hugo_es SITE_BASEURL=\"${npm_package_config_urls_es_production}\" gulp build:website",
+    "start": "SITE_CONFIGPATH=$npm_package_config_hugo_en SITE_BASEURL=\"http://localhost/\" gulp website",
+    "start:spanish": "SITE_CONFIGPATH=$npm_package_config_hugo_es SITE_BASEURL=\"http://localhost/es/\" gulp website",
     "test": "gulp test"
   },
   "repository": {


### PR DESCRIPTION
When #33 landed, it broke the deployments because of a `go panic` caused with Hugo. I opened a ticket here spf13/hugo#2174 to alert the maintainers of `hugo` about the problem. I will outline in the PR what I did to fix it.

This patch series also includes some refactoring of the `npm run` scripts along with leveraging the `npm config` to establish some repeatable environmental variables. You can [find out more about that here](https://docs.npmjs.com/misc/scripts).