### PR TITLE
Fixing typos which swapped TX and TN.

### DIFF
--- a/content/register/tennessee.md
+++ b/content/register/tennessee.md
@@ -2,7 +2,7 @@
 date = "2016-05-26T17:17:10-04:00"
 external_link = ""
 registration_type = "by-mail"
-state_abbreviation = "TX"
-title = "Texas"
+state_abbreviation = "TN"
+title = "Tennessee"
 +++
 

--- a/content/register/texas.md
+++ b/content/register/texas.md
@@ -2,7 +2,7 @@
 date = "2016-05-26T17:17:10-04:00"
 external_link = ""
 registration_type = "by-mail"
-state_abbreviation = "TN"
-title = "Tennessee"
+state_abbreviation = "TX"
+title = "Texas"
 +++
 


### PR DESCRIPTION
tennessee.md and texas.md had swapped information. Now they have the correct information.