### PR TITLE
Update styles task reference

### DIFF
--- a/config/gulp/build.js
+++ b/config/gulp/build.js
@@ -73,7 +73,7 @@ gulp.task('build:website', [ 'build' ], function (done) {
 
 gulp.task('watch', function () {
   gutil.log(gutil.colors.cyan('watch'), 'Watching assets for changes');
-  gulp.watch('./assets/styles/**/*.scss', [ 'styles:homepage' ]);
+  gulp.watch('./assets/styles/**/*.scss', [ 'styles' ]);
   gulp.watch('./assets/scripts/**/*.js', [ 'scripts' ]);
   gulp.watch('./assets/images/**/*', [ 'images' ]);
   gutil.log(gutil.colors.cyan('watch'), 'Watching content & layouts for changes');


### PR DESCRIPTION
@maya brought up that the watch task was still watching for the old `styles:homepage` task. This patch fixes the issue.