### PR TITLE
Add new pages

### DIFF
--- a/layouts/register/new-pages/check-your-registration.html
+++ b/layouts/register/new-pages/check-your-registration.html
@@ -1,0 +1,32 @@
+<div class="usa-grid page-inner main-content">
+  <header>
+    <h1>
+      <!-- Translate me -->
+      Check your registration
+    </h1>
+  </header>
+  <form class="form-register" action="/states/" method="get">
+    <h2 class="form-register-heading">{{ $translation.homepage.state_selection.label }}</h2>
+    <label class="usa-sr-only" for="js-user-selection">
+      {{ $translation.homepage.state_selection.default }}
+    </label>
+    <select name="user-selection" id="js-user-selection">
+      <option value="">
+        {{ $translation.homepage.state_selection.default }}
+      </option>
+      {{ if eq $.Site.Params.language "english" }}
+        {{ range where .Data.Pages.ByTitle "Section" "register" }}
+          <option value="{{ replace .Title "." "" | lower | urlize }}">{{ title .Title }}</option>
+        {{ end }}
+      {{ else }}
+        {{ range where .Data.Pages.ByTitle "Section" "registrar" }}
+          <option value="{{ .Slug }}">{{ title .Title }}</option>
+        {{ end }}
+      {{ end }}
+    </select>
+    <button class="usa-button-big usa-button-disabled" id="js-user-submit" type="submit">
+      <!-- Translate me -->
+      Learn how to check your registration
+    </button>
+  </form>
+</div>

--- a/layouts/register/new-pages/find-your-polling-place.html
+++ b/layouts/register/new-pages/find-your-polling-place.html
@@ -1,0 +1,42 @@
+<div class="usa-grid page-inner main-content">
+  <header>
+    <h1>
+      <!-- Translate me -->
+      Check your registration
+    </h1>
+  </header>
+  <p class="usa-font-lead">
+    <!-- Translate me -->
+    Enter your current address to find your polling place.
+  </p>
+
+  <!-- Translate me [address form text] -->
+  <form class="usa-form-large">
+    <fieldset>
+      <legend>Mailing address</legend>
+      <label for="mailing-address-1">Street address 1</label>
+      <input id="mailing-address-1" name="mailing-address-1" type="text">
+      <label for="mailing-address-2">Street address 2 <span class="usa-additional_text">Optional</span></label>
+      <input id="mailing-address-2" name="mailing-address-2" type="text">
+      <div>
+        <div class="usa-input-grid usa-input-grid-medium">
+          <label for="city">City</label>
+          <input id="city" name="city" type="text">
+        </div>
+        <div class="usa-input-grid usa-input-grid-small">
+          <label for="state">State</label>
+          <select id="state" name="state">
+            <option value=""></option>
+            <!-- Add all state options -->
+          </select>
+        </div>
+      </div>
+      <label for="zip">ZIP</label>
+      <input class="usa-input-medium" id="zip" name="zip" type="text" pattern="[\d]{5}(-[\d]{4})?" data-grouplength="5,4" data-delimiter="-" data-politespace="">
+    </fieldset>
+    <button class="usa-button-big usa-button-disabled" id="js-user-submit" type="submit">
+      <!-- Translate me -->
+      Submit
+    </button>
+  </form>
+</div>

--- a/layouts/register/new-pages/learn-about-voting-in-your-state.html
+++ b/layouts/register/new-pages/learn-about-voting-in-your-state.html
@@ -1,0 +1,32 @@
+<div class="usa-grid page-inner main-content">
+  <header>
+    <h1>
+      <!-- Translate me -->
+      Learn about voting in your state
+    </h1>
+  </header>
+  <form class="form-register" action="/states/" method="get">
+    <h2 class="form-register-heading">{{ $translation.homepage.state_selection.label }}</h2>
+    <label class="usa-sr-only" for="js-user-selection">
+      {{ $translation.homepage.state_selection.default }}
+    </label>
+    <select name="user-selection" id="js-user-selection">
+      <option value="">
+        {{ $translation.homepage.state_selection.default }}
+      </option>
+      {{ if eq $.Site.Params.language "english" }}
+        {{ range where .Data.Pages.ByTitle "Section" "register" }}
+          <option value="{{ replace .Title "." "" | lower | urlize }}">{{ title .Title }}</option>
+        {{ end }}
+      {{ else }}
+        {{ range where .Data.Pages.ByTitle "Section" "registrar" }}
+          <option value="{{ .Slug }}">{{ title .Title }}</option>
+        {{ end }}
+      {{ end }}
+    </select>
+    <button class="usa-button-big usa-button-disabled" id="js-user-submit" type="submit">
+      <!-- Translate me -->
+      View state voting guide
+    </button>
+  </form>
+</div>

--- a/layouts/register/new-pages/no-polling-place-found.html
+++ b/layouts/register/new-pages/no-polling-place-found.html
@@ -1,0 +1,16 @@
+<div class="usa-grid page-inner main-content">
+  <header>
+    <h1>
+      <!-- Translate me -->
+      Find your polling place
+    </h1>
+  </header>
+  <p class="usa-font-lead">
+    <!-- Translate me -->
+    We’re sorry: We don’t have updated information on your polling place at this time. Please check back within two weeks of your upcoming election.
+  </p>
+  <p>
+    <!-- Translate me -->
+    You can also check your polling place at the <a href="#">State of California Elections Commission website</a>.
+  </p>
+</div>

--- a/layouts/register/new-pages/state-voting-guide.html
+++ b/layouts/register/new-pages/state-voting-guide.html
@@ -1,0 +1,64 @@
+<div class="usa-grid page-inner main-content">
+  <header>
+    <h1>
+      <!-- Translate me -->
+      You’re voting in ((California)).
+    </h1>
+  </header>
+  <h6>Upcoming Election</h6>
+  <p class="font-serif">
+    June 7, 2016<br>
+    Presidential primary election
+  </p>
+  <h3>Register to vote</h3>
+  <p>California residents can register to vote online. To vote in the upcoming election, you must register by May 23.</p>
+  <a href="#">Start your online registration</a>
+  <h3>Check your registration</h3>
+  <p>Find out whether you’re registered to vote at your current address.</p>
+  <a href="#">Check your registration status</a>
+
+  <!-- Ways to vote BEGIN -->
+  <h3>Ways to vote</h3>
+  <div class="graphic-list">
+    <div class="usa-width-one-third">
+      <img src="{{ .Site.BaseURL }}assets/img/step-1.png">
+      <h4 class="usa-graphic-list-heading">
+        Vote by mail
+      </h4>
+      <p>
+        To vote by mail, you must request a vote-by-mail ballot by May 31. Your ballot must be postmarked or returned in person by June 7.
+      </p>
+      <a href="#">Request a vote-by-mail ballot</a>
+    </div>
+    <div class="usa-width-one-third">
+      <img src="{{ .Site.BaseURL }}assets/img/step-2.png">
+      <h4 class="usa-graphic-list-heading">
+        Vote in person
+      </h4>
+      <p>
+        You can vote at the polls on Election Day, June 7, from 7:00 a.m. to 8:00 p.m.
+      </p>
+      <p>
+        Some counties also offer early voting at a few locations before Election Day.
+      </p>
+      <a href="#">Find your polling place</a>
+    </div>
+    <div class="usa-width-one-third">
+      <img src="{{ .Site.BaseURL }}assets/img/step-3.png">
+      <h4 class="usa-graphic-list-heading">
+        Absentee voting
+      </h4>
+      <p>
+        California allows absentee voting for residents who [lorem ipsum]. You must request an absentee ballot by date and return it by [date].
+      </p>
+      <a href="#">Learn more about absentee voting</a>
+    </div>
+  </div>
+  <!-- Ways to vote END -->
+
+  <h3>Election day</h3>
+  <p>Learn about what to expect on election day in California at the <a href="#">vote411.org California Election Guide</a>.</p>
+  <h3>Other resources</h3>
+  <p>See past election results for your state at the <a href="#">State of California Elections Commission website</a>.</p>
+  <p>Look up campaign finance data on the upcoming election at <a href="#">beta.fec.gov</a>.</p>
+</div>

--- a/layouts/register/new-pages/your-polling-place.html
+++ b/layouts/register/new-pages/your-polling-place.html
@@ -1,0 +1,32 @@
+<div class="usa-grid page-inner main-content">
+  <header>
+    <h1>
+      <!-- Translate me -->
+      Your polling place
+    </h1>
+  </header>
+  <p class="usa-font-lead">
+    <!-- Translate me -->
+    Enter your current address to find your polling place.
+  </p>
+  <div class="address">
+    <h3>San Francisco Community Center</h3>
+    <p>456 Hill Street<br>
+    San Francisco, CA 94112</p>
+  </div>
+  <h3>Accessibility</h3>
+  <p>Polls are open at your polling place on Election Day from 7:00 a.m. until 8:00 p.m.</p>
+  <h3>Hours</h3>
+  <p>Find out whether you’re registered to vote at your current address.</p>
+  <h3>Early voting</h3>
+  <p>You can also participate in early in-person voting between [date and date, from time until time.]</p>
+  <p>Early voting is located at:</p>
+  <p>
+    <b>City Hall </b>
+    <br>
+    456 Hill Street 
+    <br>
+    San Francisco, CA 94112
+  </p>
+  <p>[Any additional information about accessibility or access.]</p>
+</div>


### PR DESCRIPTION
Adds new page layouts. 

**TODOs**:

- [ ] figure out where these layouts should go/live (right now they're in a catch-all `layouts/register/new-pages/`)
- [ ] generate the pages from content

For reference, the following templates have unique views for each state:
- home page with state selected
- your polling place
- state voting guide

We can start with a demo state for each of these similar to how we did the registration pages, before adding all states.

These pages are singular:
- check your registration
- find your polling place
- no polling place found
- learn about voting

Then translations can be added in, but might be another PR.

cc: @rogeruiz 