### PR TITLE
Update KS voter registration website link

### DIFF
--- a/content/register/kansas.md
+++ b/content/register/kansas.md
@@ -1,6 +1,6 @@
 +++
 date = "2016-05-26T17:17:07-04:00"
-external_link = "https://www.kdor.org/voterregistration/Default.aspx"
+external_link = "https://www.kdor.ks.gov/Apps/VoterReg/Default.aspx"
 registration_type = "online"
 state_abbreviation = "KS"
 title = "Kansas"


### PR DESCRIPTION
Originally proposed for usagov/vote-2016: https://github.com/usagov/vote-2016/pull/2.

Then @jwbowers told me about 18F/vote-gov: https://github.com/presidential-innovation-fellows/vote-2016/issues/116.

Cheers and thank you for helping people register to vote!