### PR TITLE
Updated language

### DIFF
--- a/data/translations/english/homepage.toml
+++ b/data/translations/english/homepage.toml
@@ -2,6 +2,6 @@ header = "Register to vote"
 
 [state_selection]
 
-label = "Where do you vote?"
+label = "Where do you reside?"
 default = "Select your state or territory"
 submit = "Find out how to register"

--- a/data/translations/english/micro_copy.toml
+++ b/data/translations/english/micro_copy.toml
@@ -1,4 +1,4 @@
 domain = "vote.gov"
 go_back = "Go back"
 skip_text = "Skip to main content"
-disclaimer = "An official website of the United States Government"
+disclaimer = "An official website of the United States government"

--- a/data/translations/english/register.toml
+++ b/data/translations/english/register.toml
@@ -1,7 +1,7 @@
 heading = "Register to Vote"
 
 [by_mail]
-body = "%state_name% allows residents to register online."
+body = "%state_name% requires residents to register by mail."
 step_one_label = "Step 1"
 step_one = "Fill out your voter registration."
 step_two_label = "Step 2"


### PR DESCRIPTION
States like New Jersey and Idaho do not have online registration. You can change the language again, if you think there's a saying that makes more sense, but it's important to make sure that distinction was being made between them and state with online registration.