### PR TITLE
Update MN voter registration website link

### DIFF
--- a/content/register/minnesota.md
+++ b/content/register/minnesota.md
@@ -1,6 +1,6 @@
 +++
 date = "2016-05-26T17:17:08-04:00"
-external_link = "https://mnvotes.sos.state.mn.us/VoterRegistration/VoterRegistrationStep1.aspx"
+external_link = "https://mnvotes.sos.state.mn.us/VoterRegistration/VoterRegistrationMain.aspx"
 registration_type = "online"
 state_abbreviation = "MN"
 title = "Minnesota"


### PR DESCRIPTION
The existing link for Minnesota voter registration redirects to an error page. This change would update the link to a valid URL.