### PR TITLE
States toml fixes

### DIFF
--- a/data/translations/english/states.toml
+++ b/data/translations/english/states.toml
@@ -55,8 +55,8 @@ file = "idaho"
 title = "Ídaho"
 
 [illinois]
-file = "ilinois"
-title = "Ilinóis"
+file = "illinois"
+title = "Illinois"
 
 [indiana]
 file = "indiana"
@@ -83,20 +83,20 @@ file = "maine"
 title = "maine"
 
 [maryland]
-file = "mariland"
-title = "Máriland"
+file = "maryland"
+title = "Maryland"
 
 [massachusetts]
-file = "masachusets"
-title = "Masachusets"
+file = "massachusetts"
+title = "Massachusetts"
 
 [michigan]
 file = "michigan"
 title = "Míchigan"
 
 [minnesota]
-file = "minesota"
-title = "Minesota"
+file = "minnesota"
+title = "Minnesota"
 
 [mississippi]
 file = "misisipi"
@@ -167,8 +167,8 @@ file = "puerto-rico"
 title = "Puerto Rico"
 
 [rhode-island]
-file = "isla-de-rode"
-title = "Isla de Rode"
+file = "rhode-island"
+title = "Rhode Island"
 
 [south-dakota]
 file = "dakota-del-sur"
@@ -203,8 +203,8 @@ file = "virginia"
 title = "Virginia"
 
 [washington-dc]
-file = "distrito-federal-de-columbia"
-title = "Distrito Federal de Columbia"
+file = "distrito-de-columbia"
+title = "Distrito de Columbia"
 
 [washington]
 file = "washington"

--- a/data/translations/spanish/states.toml
+++ b/data/translations/spanish/states.toml
@@ -85,7 +85,6 @@ file = "montana"
 [nebraska]
 file = "nebraska"
 
-
 [nevada]
 file = "nevada"
 
@@ -95,7 +94,7 @@ file = "new-hampshire"
 [nueva-jersey]
 file = "new-jersey"
 
-[nuevo-méxico]
+[nuevo-mexico]
 file = "new-mexico"
 
 [nueva-york]
@@ -116,7 +115,7 @@ file = "ohio"
 [oklahoma]
 file = "oklahoma"
 
-[oregón]
+[oregon]
 file = "oregon"
 
 [pensilvania]
@@ -140,7 +139,7 @@ file = "tennessee"
 [texas]
 file = "texas"
 
-[islas-vírgenes-de-ee-uu]
+[islas-virgenes-de-ee-uu]
 file = "us-virgin-islands"
 
 [utah]


### PR DESCRIPTION
#110 unfortunately broke the TOML parser due to accented chars in key names. It also changed some Spanish state names but didn't update the corresponding `file` attributes in `english/states.toml`. This PR aims to fix both issues.