### PR TITLE
Fix bare spaces in key name

### DIFF
--- a/data/translations/spanish/states.toml
+++ b/data/translations/spanish/states.toml
@@ -124,7 +124,7 @@ file = "pennsylvania"
 [puerto-rico]
 file = "puerto-rico"
 
-[rhode island]
+[rhode-island]
 file = "rhode-island"
 
 [dakota-del-sur]


### PR DESCRIPTION
`[rhode island]` needs a hyphen.