### PR TITLE
Support no/broken Javascript on front page form

### DIFF
--- a/config/gulp/deploy.js
+++ b/config/gulp/deploy.js
@@ -8,7 +8,7 @@ var spawn = require('cross-spawn');
 gulp.task('deploy-clean-all', function () {
   return del([
     './public',
-    './tmp/public',
+    './tmp/public'
   ]);
 });
 
@@ -34,7 +34,7 @@ gulp.task('deploy-english', function(done) {
   runSequence(
     'build:website',
     done
-  )
+  );
 
 });
 
@@ -44,20 +44,27 @@ gulp.task('deploy-spanish', function(done) {
   runSequence(
     'build:website',
     done
-  )
+  );
 
 });
 
 gulp.task('deploy-remove-remnants', function (done) {
   return del([
     './tmp/public/es/assets/',
-    './tmp/public/es/files/',
+    './tmp/public/es/files/'
   ]);
 });
 
-gulp.task('deploy-provision',function (done) {
+gulp.task('deploy-provision', function (done) {
 
   return gulp.src('./tmp/public/**/*')
+    .pipe(gulp.dest('./public'));
+
+});
+
+gulp.task('deploy-nginx-conf', function (done) {
+
+  return gulp.src('./nginx.conf')
     .pipe(gulp.dest('./public'));
 
 });
@@ -93,6 +100,7 @@ gulp.task('deploy', function (done) {
     'deploy-spanish',
     'deploy-remove-remnants',
     'deploy-provision',
+    'deploy-nginx-conf',
     done
   );
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -12,12 +12,16 @@
         <header>
           <h1 class="usa-display">{{ $translation.homepage.header }}</h1>
         </header>
+      {{ if eq $.Site.Params.language "english" }}
         <form class="form-register" action="/states/" method="get">
+      {{ else }}
+        <form class="form-register" action="/es/states/" method="get">
+      {{ end }}
           <p>{{ $translation.homepage.state_selection.label }}</p>
           <label class="usa-sr-only" for="js-user-selection">
             {{ $translation.homepage.state_selection.default }}
           </label>
-          <select name="user-selection" id="js-user-selection">
+          <select name="userselection" id="js-user-selection">
             <option value="">
               {{ $translation.homepage.state_selection.default }}
             </option>

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,66 @@
+worker_processes 1;
+daemon off;
+
+error_log <%= ENV["APP_ROOT"] %>/nginx/logs/error.log;
+events { worker_connections 1024; }
+
+http {
+  charset utf-8;
+  log_format cloudfoundry '$http_x_forwarded_for - $http_referer - [$time_local] "$request" $status $body_bytes_sent';
+  access_log <%= ENV["APP_ROOT"] %>/nginx/logs/access.log cloudfoundry;
+  default_type application/octet-stream;
+  include mime.types;
+  sendfile on;
+
+  gzip on;
+  gzip_disable "msie6";
+  gzip_comp_level 6;
+  gzip_min_length 1100;
+  gzip_buffers 16 8k;
+  gzip_proxied any;
+  gunzip on;
+  gzip_static always;
+  gzip_types text/plain text/css text/js text/xml text/javascript application/javascript application/x-javascript application/json application/xml application/xml+rss;
+
+  tcp_nopush on;
+  keepalive_timeout 30;
+  port_in_redirect off; # Ensure that redirects don't include the internal container PORT - <%= ENV["PORT"] %>
+  server_tokens off;
+
+  server {
+    listen <%= ENV["PORT"] %>;
+    server_name localhost;
+
+    location / {
+      root <%= ENV["APP_ROOT"] %>/public;
+      <% if File.exists?(File.join(ENV["APP_ROOT"], "nginx/conf/.enable_pushstate")) %>
+      if (!-e $request_filename) {
+        rewrite ^(.*)$ / break;
+      }
+      <% end %>
+      index index.html index.htm Default.htm;
+      <% if File.exists?(File.join(ENV["APP_ROOT"], "nginx/conf/.enable_directory_index")) %>
+        autoindex on;
+      <% end %>
+      <% if File.exists?(auth_file = File.join(ENV["APP_ROOT"], "nginx/conf/.htpasswd")) %>
+        auth_basic "Restricted";                                #For Basic Auth
+        auth_basic_user_file <%= auth_file %>;  #For Basic Auth
+      <% end %>
+      <% if ENV["FORCE_HTTPS"] %>
+        if ($http_x_forwarded_proto != "https") {
+          return 301 https://$host$request_uri;
+        }
+      <% end %>
+      <% if File.exists?(File.join(ENV["APP_ROOT"], "nginx/conf/.enable_ssi")) %>
+        ssi on;
+      <% end %>
+
+      # Custom rewriting for vote.gov
+      # Convert form submission from front page into redirect to state page
+      rewrite_log on;
+      rewrite ^/states /register/$arg_userselection/? redirect;
+      rewrite ^/es/states /registrar/$arg_userselection/? redirect;
+
+    }
+  }
+}


### PR DESCRIPTION
Currently, the front page form gives a 404 if the user has JS disabled, or if the button click event fails to fire. This PR adds an `nginx.conf` file, based on the standard [`static-buildpack` config](https://github.com/cloudfoundry/staticfile-buildpack/blob/master/conf/nginx.conf) with a couple of additional rewrite rules so that the form works without JS. (A couple of minor tweaks to the form were also needed to ensure that language choice is carried across.)

Currently deployed here: https://vote-gov-no-js.apps.cloud.gov/

In theory we could remove the front page JS entirely, since this config now takes care of page routing, but this PR doesn't do that.