### PR TITLE
Zero downtime push

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -35,10 +35,10 @@ deployment:
     commands:
       - NODE_ENV=production npm run deploy
       - cf login -a https://api.cloud.gov -u $CF_GSA_VOTE_USER -p $CF_GSA_VOTE_PASS -o gsa-ffd -s vote-production
-      - cf zero-downtime-push -f manifest.yml
+      - cf zero-downtime-push vote-gov -f manifest.yml
   staging:
     branch: [staging]
     commands:
       - npm run deploy
       - cf login -a https://api.cloud.gov -u $CF_GSA_VOTE_USER -p $CF_GSA_VOTE_PASS -o gsa-ffd -s vote-staging
-      - cf zero-downtime-push -f manifest-staging.yml
+      - cf zero-downtime-push vote-gov-staging -f manifest-staging.yml

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,7 @@
 machine:
   environment:
     CIRCLE_BUILD_DIR: $HOME/$CIRCLE_PROJECT_REPONAME
+    GOPATH: "${HOME}/.go_workspace"
     PATH: $PATH:$CIRCLE_BUILD_DIR/bin
   post:
     - mkdir -p $CIRCLE_BUILD_DIR/bin
@@ -8,8 +9,6 @@ machine:
     version: 5.1.0
   ruby:
     version: 2.3.0
-  environment:
-    GOPATH: "${HOME}/.go_workspace"
 
 dependencies:
   pre:

--- a/circle.yml
+++ b/circle.yml
@@ -16,6 +16,8 @@ dependencies:
     - sudo dpkg -i debs/temp.deb
     - cf -v
     - rm -rf ./node_modules
+    - go get github.com/concourse/autopilot
+    - cf install-plugin $GOPATH/bin/autopilot -f
     - bash ./config/ci/install-hugo.sh
   cache_directories:
     - debs
@@ -33,10 +35,10 @@ deployment:
     commands:
       - NODE_ENV=production npm run deploy
       - cf login -a https://api.cloud.gov -u $CF_GSA_VOTE_USER -p $CF_GSA_VOTE_PASS -o gsa-ffd -s vote-production
-      - cf push
+      - cf zero-downtime-push -f manifest.yml
   staging:
     branch: [staging]
     commands:
       - npm run deploy
       - cf login -a https://api.cloud.gov -u $CF_GSA_VOTE_USER -p $CF_GSA_VOTE_PASS -o gsa-ffd -s vote-staging
-      - cf push -f manifest-staging.yml
+      - cf zero-downtime-push -f manifest-staging.yml

--- a/circle.yml
+++ b/circle.yml
@@ -8,6 +8,8 @@ machine:
     version: 5.1.0
   ruby:
     version: 2.3.0
+  environment:
+    GOPATH: "${HOME}/.go_workspace"
 
 dependencies:
   pre:


### PR DESCRIPTION
Tweaks the CircleCI config to use [Autopilot](https://github.com/contraband/autopilot), which keeps the app up during deploys.