### PR TITLE
Fix cutoff banner text

### DIFF
--- a/assets/styles/component/disclaimer.scss
+++ b/assets/styles/component/disclaimer.scss
@@ -18,7 +18,6 @@
   line-height: 1rem;
   margin-top: 0.25rem;
   width: 60%;
-  overflow: hidden;
 
   @include media($medium-screen) {
     margin-top: 1rem;
@@ -33,10 +32,6 @@
   @include media($medium-screen) {
     padding-top: 0;
   }
-}
-
-.usa-disclaimer-official__body {
-  overflow: hidden;
 }
 
 .translations {


### PR DESCRIPTION
The top and bottom letters of the banner text "An official website of the United States government." are cutoff. This fixes that by removing `overflow: hidden`.

Fixes #100.
## This is what it looks like:
### Desktop:

<img width="339" alt="screen shot 2016-09-23 at 9 25 04 am" src="https://cloud.githubusercontent.com/assets/5249443/18793552/1bda416c-8170-11e6-819b-9c09047523a4.png">
### Mobile:

<img width="360" alt="screen shot 2016-09-23 at 9 25 14 am" src="https://cloud.githubusercontent.com/assets/5249443/18793556/1f36a0c6-8170-11e6-80da-96c6bd30a1f0.png">

cc @rogeruiz @shawnbot 
