### PR TITLE
Nginx conf changes suggested by Compliance Viewer

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -35,8 +35,12 @@ http {
       root <%= ENV["APP_ROOT"] %>/public;
 
       index index.html;
-
       error_page 404 /404.html;
+
+      add_header X-Frame-Options SAMEORIGIN;
+      add_header X-Content-Type-Options nosniff;
+      add_header X-XSS-Protection 0;
+      expires 300;
       
       # Custom rewriting for vote.gov
       # Convert form submission from front page into redirect to state page


### PR DESCRIPTION
Compliance viewer scan: https://compliance-viewer.18f.gov/results/vote.gov/current

I've turned off XSS protection because we have no dynamic page text, but we do have query string arguments in use, and I want to avoid false positives: http://blog.innerht.ml/the-misunderstood-x-xss-protection/
