### PR TITLE
Tweak to catch clicks without selection

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -18,7 +18,7 @@
             {{ $translation.homepage.state_selection.default }}
           </label>
           <select name="userselection" id="js-user-selection">
-            <option value="">
+            <option value="default">
               {{ $translation.homepage.state_selection.default }}
             </option>
           {{ range where .Data.Pages.ByTitle "Section" .Site.Params.register_path }}

--- a/nginx.conf
+++ b/nginx.conf
@@ -44,7 +44,7 @@ http {
       rewrite ^/states/ " /register/$arg_userselection/?" redirect;
       rewrite ^/es/states/ " /es/registrar/$arg_userselection/?" redirect;
       rewrite ^/register/(default)?/ " /" redirect;
-      rewrite ^/es/registrar/(default)?/ " /" redirect;
+      rewrite ^/es/registrar/(default)?/ " /es/" redirect;
 
       try_files $uri $uri/index.html $uri/ =404;
     }

--- a/nginx.conf
+++ b/nginx.conf
@@ -43,6 +43,7 @@ http {
       rewrite_log on;
       rewrite ^/states/ " /register/$arg_userselection/?" redirect;
       rewrite ^/es/states/ " /es/registrar/$arg_userselection/?" redirect;
+      rewrite ^/register/default/ " /" redirect;
 
       try_files $uri $uri/index.html $uri/ =404;
     }

--- a/nginx.conf
+++ b/nginx.conf
@@ -43,7 +43,8 @@ http {
       rewrite_log on;
       rewrite ^/states/ " /register/$arg_userselection/?" redirect;
       rewrite ^/es/states/ " /es/registrar/$arg_userselection/?" redirect;
-      rewrite ^/register/default/ " /" redirect;
+      rewrite ^/register/(default)?/ " /" redirect;
+      rewrite ^/es/registrar/(default)?/ " /" redirect;
 
       try_files $uri $uri/index.html $uri/ =404;
     }


### PR DESCRIPTION
Following @jamesharnett's [comment](https://github.com/18F/vote-gov/issues/124#issuecomment-249396839), this tweak ensures that users who click the big _Find out how to register_ button without choosing a state are just returned to the front page.

Additional possible tweaks:

 * A JS tweak suggested by @jamesharnett - disable the submit button until the stat is selected.
 * A non-JS tweak: Redirect to a second index page which includes an extra note reminding the user that they have to choose a state.