### PR TITLE
Fixing line-height in disclaimer

### DIFF
--- a/assets/styles/component/disclaimer.scss
+++ b/assets/styles/component/disclaimer.scss
@@ -15,7 +15,7 @@
 .usa-disclaimer-official {
   float: left;
   display: block;
-  line-height: 1rem;
+  line-height: 1.5rem;
   margin-top: 0.25rem;
   width: 60%;
   overflow: hidden;


### PR DESCRIPTION
The bottom of the `g` in `An official website of the United States government` is getting cut off because there is not enough line-height on the text. This fixes that. 🇺🇸👍